### PR TITLE
add tip to run command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It provides tasks for `colcon` workspace and automatically run setup scripts in 
 
 ## How to use
 
-1. Enable tasks by running command `Colcon: Enable Tasks for current Workspace` or manually set `colcon.provideTasks` to `true`.
+1. Enable tasks by running command (Ctrl + Shift + P) `Colcon: Enable Tasks for current Workspace` or manually set `colcon.provideTasks` to `true`.
 2. If default options doesn't suit your workspace, you may configure `colcon.globalSetup` and `colcon.workspaceSetup` lists of `setup` files.
 3. Run `Colcon: Refresh Environment` command to complete environment set up for your workspace.
 4. Now open yout task list and run any task you want!


### PR DESCRIPTION
first off - great vs code extension! I've used it on a few workstations now and i love it. the problem i run into is I always forget how to run the configure command in vs code and adding this little tip would save me 5min of googling each time I setup the machines.

i'm not sure if its different for different OS's...so that might just be something to add as well