### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,9 +18,10 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
-    - run: npm install
-    - run: xvfb-run -a npm test
-      if: runner.os == 'Linux'
-    - run: npm test
-      if: runner.os != 'Linux'
+        node-version: 12
+    - name: Install dependencies
+      run: npm install
+    - name: Run headless test
+      uses: GabrielBB/xvfb-action@v1
+      with:
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: CI Test
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - run: npm install
+    - run: xvfb-run -a npm test
+      if: runner.os == 'Linux'
+    - run: npm test
+      if: runner.os != 'Linux'


### PR DESCRIPTION
this adds github actions to this extension to test every PR that people make to it. it wont run directly on your repo until you merge this PR....so i went ahead and made the "same PR" over on my repo so you could see what the action does.

https://github.com/flynneva/vscode-colcon-helper/pull/1

its failing right now for some reason....im not that familiar with vs code extensions to be honest so maybe you already know how to fix it? im probably missing something in the virtual environment setup before running `npm test`. maybe you know how to fix it.