### PR TITLE
Configurable colcon path and install type, basic C/C++ problem matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,9 +245,14 @@
                             "symlinked",
                             "merged"
                         ],
+                        "enumDescriptions": [
+                            "No extra options to colcon - default behavior",
+                            "Adds --symlink-install option to contributed build tasks",
+                            "Adds --merge-install option to contributed build tasks"
+                        ],
                         "default": "isolated",
                         "scope": "resource",
-                        "description": "Type of installation to perform."
+                        "description": "Type of installation to perform. Could be overridden in tasks.json for specific task."
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -252,6 +252,21 @@
                 }
             }
         ],
+        "problemMatchers": [
+            {
+                "name": "colcon-helper-gcc",
+                "fileLocation": "absolute",
+                "owner": "colcon",
+                "pattern": {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            }
+        ],
         "taskDefinitions": [
             {
                 "type": "colcon",

--- a/package.json
+++ b/package.json
@@ -231,6 +231,23 @@
                         "default": "cmd",
                         "scope": "resource",
                         "description": "Type of shell being used for process colcon tasks."
+                    },
+                    "colcon.colconExe": {
+                        "type": "string",
+                        "default": "colcon",
+                        "scope": "resource",
+                        "description": "Path to colcon executable."
+                    },
+                    "colcon.installType": {
+                        "type": "string",
+                        "enum": [
+                            "isolated",
+                            "symlinked",
+                            "merged"
+                        ],
+                        "default": "isolated",
+                        "scope": "resource",
+                        "description": "Type of installation to perform."
                     }
                 }
             }

--- a/src/colcon_config.ts
+++ b/src/colcon_config.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { colcon_ns, extName } from './common';
+import { colcon_exec, colcon_ns, def_install_type, extName } from './common';
 
 const envProperty = "env";
 const globalSetupProperty = "globalSetup";
@@ -25,11 +25,18 @@ const defaultEnvsProperty = "defaultEnvironment";
 const rosInstallPathProperty = "rosInstallPath";
 const shellProperty = "shell";
 const shellTypeProperty = "shellType";
+const colconExeProperty = "colconExe";
+const installTypeProperty = "installType";
 
 /**
  * Recognizable shell types
  */
 type ShellType = 'cmd' | 'powershell' | 'bash' | 'zsh';
+
+/**
+ * Recognizable installation types
+ */
+type InstallType = 'isolated' | 'symlinked' | 'merged';
 
 enum OutputLevel {
     Info = 0,
@@ -63,6 +70,9 @@ export class Config {
     globalSetup: string[] = [];
     workspaceSetup: string[] = [];
     colconCwd: string;
+    colconExe: string;
+    installType: string;
+    installTypeArgs: string[] = [];
     currentWsFolder: vscode.WorkspaceFolder;
 
     refreshOnStart: boolean;
@@ -165,6 +175,21 @@ export class Config {
         {
             // leave undefined if there is no envs defined
             this.defaultEnvs = envs;
+        }
+
+        this.colconExe = this.resolvePath(this.resConf.get(colconExeProperty, colcon_exec));
+        this.installType = this.resConf.get(installTypeProperty, def_install_type);
+        switch (this.installType)
+        {
+            case "symlinked":
+                this.installTypeArgs.push('--symlink-install');
+                break;
+            case "merged":
+                this.installTypeArgs.push('--merge-install');
+                break;
+            default:
+                // isolated install is the default case
+                break;
         }
     }
 

--- a/src/colcon_task_provider.ts
+++ b/src/colcon_task_provider.ts
@@ -65,7 +65,7 @@ export function createColconTaskProvider() {
                     definition.name ?? _task.name,
                     definition.type,
                     new vscode.ProcessExecution(
-                        definition.command ?? colcon_exec,
+                        definition.command ?? config.colconExe,
                         definition.args ?? [],
                         execOptions),
                     []

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,6 @@
 export const colcon_exec = 'colcon';
 export const colcon_ns = colcon_exec;
+export const def_install_type = 'isolated'
 export const extName = "Colcon Tasks";
 
 export const ros2launch = 'ros2 launch';

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -13,7 +13,7 @@ export class PackageInfo implements vscode.QuickPickItem {
 }
 
 export function getAllPackages(folder: vscode.WorkspaceFolder): PackageInfo[] {
-    let cmd = [colcon_exec].concat('list');
+    let cmd = [config.colconExe].concat('list');
 
     var joinedCmd = cmd.join(' ');
     config.log("Get package list with: " + joinedCmd);

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -28,7 +28,7 @@ export function getBuildTaskForPackage(packageName: string | string[]): vscode.T
 
     return makeColconTask(
         `build ${descriptor}`,
-        [buildCmd, '--symlink-install', '--packages-select'].concat(packageName),
+        [buildCmd].concat(config.installTypeArgs).concat('--packages-select', packageName),
         vscode.TaskGroup.Build);
 }
 
@@ -40,7 +40,7 @@ export function getBuildTaskForPackagesUpTo(packageName: string | string[]): vsc
 
     return makeColconTask(
         `build ${descriptor}`,
-        [buildCmd, '--symlink-install', '--packages-up-to'].concat(packageName),
+        [buildCmd].concat(config.installTypeArgs).concat('--packages-up-to', packageName),
         vscode.TaskGroup.Build);
 }
 
@@ -85,7 +85,7 @@ let makeColconTask = (
     args: string[],
     group: vscode.TaskGroup | undefined = undefined
 ) => {
-    return makeTask(colcon_exec, taskName, args, group);
+    return makeTask(config.colconExe, taskName, args, group);
 }
 
 // Get all possible colcon tasks
@@ -132,7 +132,7 @@ export function getColconTasks(wsFolder: vscode.WorkspaceFolder) {
         }
     }
 
-    pushIfNotUndefined(makeColconTask('build', [buildCmd, '--symlink-install'], vscode.TaskGroup.Build));
+    pushIfNotUndefined(makeColconTask('build', [buildCmd].concat(config.installTypeArgs), vscode.TaskGroup.Build));
     pushIfNotUndefined(makeColconTask('test', [testCmd], vscode.TaskGroup.Test));
     pushIfNotUndefined(makeColconTask('test-result', [testResultCmd, '--verbose']));
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -85,7 +85,11 @@ let makeColconTask = (
     args: string[],
     group: vscode.TaskGroup | undefined = undefined
 ) => {
-    return makeTask(config.colconExe, taskName, args, group);
+    let newTask = makeTask(config.colconExe, taskName, args, group);
+    if (group === vscode.TaskGroup.Build) {
+      newTask.problemMatchers = ['$colcon-helper-gcc'];
+    }
+    return newTask;
 }
 
 // Get all possible colcon tasks


### PR DESCRIPTION
Hi Dmitriy,

I found this extension very useful and would like to contribute back few minor modifications which I personally required for my work.

1. ability to pick the executable name (path) for colcon
2. problem matcher for C/C++(might also close #16 ?)

My use case for 1. is:
I have a Bash script in my workspace that wraps colcon, giving me a chance to generate a `colcon.meta` config file prior to building and to set extra `--cmake-args` to create `compile_commands.json`. Finally, I'm able to merge all `compile_commands.json` files into one using `jq` post-build to get C/C++ completion working ("IntelliSense").

All the best,
Felix